### PR TITLE
DTP-4295 Update checkstyle for new version

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -219,7 +219,7 @@
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Bean, Before, BeforeEach, Override, Test"/>


### PR DESCRIPTION
As of 8.42 Javadoc method uses accessModifiers instead of scope, see: https://github.com/jshiell/checkstyle-idea/issues/525#issuecomment-832084505