### PR TITLE
MKC-5431: Add optional FinalLocalVariable check

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -241,6 +241,11 @@
         </module>
         <module name="CommentsIndentation"/>
         <module name="UnusedImports"/>
+        <module name="FinalLocalVariable">
+            <property name="severity" value="${checkstyle.finallocalvariable.severity}" default="ignore"/>
+            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+            <property name="validateEnhancedForLoopVariable" value="true"/>
+        </module>
     </module>
 </module>
 


### PR DESCRIPTION
This adds the Checkstyle check that makes you put 'final' before variables in parameters and local variables if they're not assigned.

This can be enabled in a project with: 

```gradle
checkstyle {
    ...
    configProperties = [
        'checkstyle.finallocalvariable.severity': 'ERROR'
    ]
    ...
}
```

It seems the campaigns team likes this convention, but I didn't want to break every other project using this config file. So, it is disabled by default (severity level = IGNORE).